### PR TITLE
Attempting to convince Github this file is JSON

### DIFF
--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -1,5 +1,1 @@
-{
-     "appclips": {
-         "apps": ["3JZ8T294M7.com.digimarc.mobile.DigimarcDiscover.clip"]
-     }
-}
+apple-app-site-association.json

--- a/.well-known/apple-app-site-association.json
+++ b/.well-known/apple-app-site-association.json
@@ -1,0 +1,11 @@
+{
+     "applinks": {
+     }
+     "activitycontinuation": {
+     }
+     "appclips": {
+          "apps": [
+               "3JZ8T294M7.com.digimarc.mobile.DigimarcDiscover.clip"
+          ]
+     }
+}


### PR DESCRIPTION
Apple does something weird where they don't want a json extension on their file, but it needs the correct mime type. Github can't figure out the mime type because there is no extension.

Trying to force the recognition by using a symlink.